### PR TITLE
Added test for normalization consistency

### DIFF
--- a/chime_utils/bin/org_tools.py
+++ b/chime_utils/bin/org_tools.py
@@ -306,9 +306,13 @@ def compute_stats(dasr_root, corpus_name):  # compute speech stats from JSONs
     help="Which text norm, chime8, chime6, chime7 or none",
 )
 def test_norm_consistency(dasr_root, text_norm="chime8"):
-    # Christoph's idea:
-    # fetch all utterances and check if applying two times the normalizer
-    # something changes
+    """
+    Christoph's idea:
+    fetch all utterances and check if applying two times the normalizer
+    something changes.
+    Normalization should always be consistent.
+    """
+
     std = get_txt_norm(text_norm)
     # fetch all possible transcriptions
     json_files = glob.glob(os.path.join(dasr_root, "**/*.json"), recursive=True)

--- a/chime_utils/text_norm/whisper_like/english.json
+++ b/chime_utils/text_norm/whisper_like/english.json
@@ -86,7 +86,7 @@
     "archaeologically": "archeologically",
     "archaeologist": "archeologist",
     "archaeologists": "archeologists",
-    "archaeology": "archeology</span>",
+    "archaeology": "archeology",
     "ardour": "ardor",
     "armour": "armor",
     "armoured": "armored",

--- a/chime_utils/text_norm/whisper_like/english.py
+++ b/chime_utils/text_norm/whisper_like/english.py
@@ -471,6 +471,7 @@ class EnglishTextNormalizer:
                 "hmm"
             ),
             r"\b(a+h+)\b|\b(ha+)\b": "ah",
+            r"[!?.]+(?=$|\s)": "",  # Okay.. --> okay
             r"\b(o+h+)\b|\b(h+o+)\b": "oh",
             r"\b(u+h+)\b|\b(h+u+)\b|\b(h+u+h+)\b": "uh",
             # common contractions

--- a/chime_utils/text_norm/whisper_like/english.py
+++ b/chime_utils/text_norm/whisper_like/english.py
@@ -455,8 +455,8 @@ class EnglishSpellingNormalizer:
     [1] https://www.tysto.com/uk-us-spelling-list.html
     """
 
-    def __init__(self):
-        mapping_path = os.path.join(os.path.dirname(__file__), "english.json")
+    def __init__(self, mapping_name="english.json"):
+        mapping_path = os.path.join(os.path.dirname(__file__), mapping_name)
         self.mapping = json.load(open(mapping_path))
 
     def __call__(self, s: str):
@@ -470,7 +470,6 @@ class EnglishTextNormalizer:
             r"\b(hm+)\b|\b(mhm)\b|\b(mm+)\b|\b(m+h)\b|\b(hm+)\b|\b(um+)\b|\b(uhm+)\b": (  # noqa e501
                 "hmm"
             ),
-            # r"\bt v\b": "tv",
             r"\b(a+h+)\b|\b(ha+)\b": "ah",
             r"\b(o+h+)\b|\b(h+o+)\b": "oh",
             r"\b(u+h+)\b|\b(h+u+)\b|\b(h+u+h+)\b": "uh",
@@ -535,6 +534,7 @@ class EnglishTextNormalizer:
         else:
             self.standardize_numbers = None
         self.standardize_spellings = EnglishSpellingNormalizer()
+        self.pre_standardize_spellings = EnglishSpellingNormalizer("pre_english.json")
 
     def __call__(self, s: str):
         s = s.lower()
@@ -543,6 +543,7 @@ class EnglishTextNormalizer:
         # remove words between brackets
         s = re.sub(r"\(([^)]+?)\)", "", s)
         # remove words between parenthesis
+        s = self.pre_standardize_spellings(s)
         s = re.sub(r"\s+'", "'", s)
         # when there's a space before an apostrophe
 
@@ -558,8 +559,8 @@ class EnglishTextNormalizer:
 
         if self.standardize_numbers is not None:
             s = self.standardize_numbers(s)
-        s = self.standardize_spellings(s)
 
+        s = self.standardize_spellings(s)
         # now remove prefix/suffix symbols
         # that are not preceded/followed by numbers
         s = re.sub(r"[.$¢€£]([^0-9])", r" \1", s)

--- a/chime_utils/text_norm/whisper_like/pre_english.json
+++ b/chime_utils/text_norm/whisper_like/pre_english.json
@@ -1,0 +1,5 @@
+{
+  "shan't": "shall not",
+  "han't": "has not",
+  "ain't": "ain not"
+}

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -5,6 +5,8 @@ from chime_utils.text_norm.whisper_like import EnglishTextNormalizer
 
 @pytest.mark.parametrize("std", [EnglishTextNormalizer()])
 def test_text_normalizer(std):
+    assert std("shan't") == "shall not"
+    assert std("han't") == "has not"
     assert std("Let's") == "let us"
     assert std("he's like") == "he is like"
     assert std("she's been like") == "she has been like"


### PR DESCRIPTION
@boeddeker as you suggested. 
I added a tool for checking double application consistency for the text normalization. 
The test runs smoothly now. I covered some edge cases: 

1. "Okay.." --> okay 
2. archeology was mapped to archeology<\span> in Whisper ?! for some reason



