### PR TITLE
fix notsofar dev set version and imrpove exception msg

### DIFF
--- a/chime_utils/dgen/notsofar1.py
+++ b/chime_utils/dgen/notsofar1.py
@@ -2,6 +2,7 @@ import glob
 import json
 import logging
 import os
+import subprocess
 from copy import deepcopy
 from pathlib import Path
 
@@ -23,10 +24,38 @@ logger = logging.getLogger(__name__)
 NOTSOFAR1_FS = 16000
 
 
+_check_version_exists_cache = None
+
+
+def check_version_exists(version):
+    global _check_version_exists_cache
+    if _check_version_exists_cache is None:
+        cmd = (
+            "az storage blob list "
+            "--container-name benchmark-datasets "
+            "--account-name notsofarsa "
+            '--prefix "" '
+            '--delimiter "MTG" '
+            '--query "[].name"'
+        )
+        _check_version_exists_cache = subprocess.check_output(cmd, shell=True).decode(
+            "utf-8"
+        )
+
+    if version in _check_version_exists_cache:
+        return True
+    else:
+        raise RuntimeError(
+            f"Version {version} does not exist (anymore) in NOTSOFAR1 dataset !\n"
+            f"Available: (pattern: <subset_name>/<version>/...)"
+            f" {_check_version_exists_cache}"
+        )
+
+
 def download_notsofar1(download_dir, subset_name):
     if subset_name == "dev":
         subset_name = "dev_set"
-        version = "240415.2_dev_with_GT"
+        version = "240825.1_dev1"
     elif subset_name == "train":
         subset_name = "train_set"
         version = "240501.1_train"
@@ -35,9 +64,14 @@ def download_notsofar1(download_dir, subset_name):
         version = "240629.1_eval_small"
     else:
         raise RuntimeError("Evaluation data has not yet been released !")
-    dev_meetings_dir = download_meeting_subset(
-        subset_name=subset_name, version=version, destination_dir=str(download_dir)
-    )
+    try:
+        dev_meetings_dir = download_meeting_subset(
+            subset_name=subset_name, version=version, destination_dir=str(download_dir)
+        )
+    except FileNotFoundError:
+        check_version_exists(version)  # will raise a better exception message
+        raise
+
     if dev_meetings_dir is None:
         logger.error(f"Failed to download {subset_name} for NOTSOFAR1 dataset")
 


### PR DESCRIPTION
Yesterday, the NOTSOFAR Team deleted the old dev set and added a new dev set.

In this PR, I fixed the dev set version to be the new one and improved the exception message.
If you don't like the change of the exception msg, I can remove the code.

Example exception message:
```python
...
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpwt2c6tww/benchmark-datasets/dev_set/240415.2_dev_with_GT/MTG' -> '/scratch/hpc-prf-nt1/cbj/deploy/tssep_data/egs/libri_css/data/chime-utils/download/notsofar1/dev/dev_set/240415.2_dev_with_GT/MTG'
...
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpwt2c6tww/benchmark-datasets/dev_set/240415.2_dev_with_GT/MTG'
...
RuntimeError: Version 240415.2_dev_with_GT does not exist in NOTSOFAR1 dataset !
Available: (pattern: <subset_name>/<version>/...)[
  "dev_set/240130.1_dev/MTG",
  "dev_set/240208.2_dev/MTG",
  "dev_set/240825.1_dev1/MTG",
  "eval_set/240629.1_eval_small/MTG",
  "eval_set/240629.1_eval_small_with_GT/MTG",
  "eval_set/240825.1_eval_full_with_GT/MTG",
  "train_set/240130.1_train/MTG",
  "train_set/240208.2_train/MTG",
  "train_set/240229.1_train/MTG",
  "train_set/240415.1_train/MTG",
  "train_set/240501.1_train/MTG",
  "train_set/240825.1_train/MTG",
  "dev_set/240825.1_dev1/logs/README.txt",
  "eval_set/240825.1_eval_full_with_GT/logs/README.txt",
  "train_set/240825.1_train/logs/README.txt"
]
```

Open points:
 - Should somewhere `240825.1_eval_full_with_GT` be added? The second eval set.
 - Should the train set be replaced? The old still exists, but there is a new one with some bugfixes.