### PR TITLE
Modification of NOTSOFAR-1 dataprep to support single channel condition

### DIFF
--- a/chime_utils/dgen/notsofar1.py
+++ b/chime_utils/dgen/notsofar1.py
@@ -130,7 +130,7 @@ def convert2chime(
     output_devices_info = os.path.join(output_root, "devices", c_split)
     os.makedirs(output_devices_info, exist_ok=True)
 
-    if c_split in ["train", "train_sc", "dev", "eval"]:
+    if c_split in ["train", "train_sc", "dev", "dev_sc", "eval", "eval_sc"]:
         # dump transcriptions
         output_txt_f = os.path.join(output_root, "transcriptions", c_split)
         os.makedirs(output_txt_f, exist_ok=True)
@@ -171,7 +171,7 @@ def convert2chime(
         }
         devices_info[device_name] = d_type
 
-    if c_split not in ["train", "train_sc", "dev", "eval"]:
+    if c_split not in ["train", "train_sc", "dev", "dev_sc", "eval", "eval_sc"]:
         devices_info = dict(sorted(devices_info.items(), key=lambda x: x[0]))
         with open(os.path.join(output_devices_info, f"{session_name}.json"), "w") as f:
             json.dump(devices_info, f, indent=4)
@@ -303,10 +303,8 @@ def gen_notsofar1(
     with open(uem_file, "w") as f:
         f.writelines(uem_data)
 
-    if dset_part not in ["train"]:
-        return
     # also prep sc data
-    uem_file_sc = os.path.join(output_dir, "uem", "train_sc", "all.uem")
+    uem_file_sc = os.path.join(output_dir, "uem", f"{dset_part}_sc", "all.uem")
     Path(uem_file_sc).parent.mkdir(parents=True, exist_ok=True)
     uem_data_sc = []
     for device_j in device_jsons:
@@ -336,7 +334,7 @@ def gen_notsofar1(
             sess_name = sess_map[f"{orig_sess_name}_{device_name}_sc"]
 
             convert2chime(
-                "train_sc",
+                f"{dset_part}_sc",
                 device_folder,
                 sess_name,
                 spk_map,

--- a/chime_utils/dprep/lhotse.py
+++ b/chime_utils/dprep/lhotse.py
@@ -181,7 +181,6 @@ def prepare_notsofar1(
         ("train", "dev" and "eval"), and the
         value is Dicts with the keys 'recordings' and 'supervisions'.
     """
-    assert mic in ["ihm", "mdm"], "mic must be one of 'ihm' or 'mdm'"
     manifests = prep_lhotse_shared(
         corpus_dir, output_dir, dset_part, mic, "notsofar1", json_dir, txt_norm
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 meeteval[cli] @ git+https://github.com/fgnt/meeteval
 jiwer==3.0.0
 pyannote.metrics==3.2.1
-lhotse==1.21.0
+lhotse>=1.21.0
 click==8.1.7
 torchaudio>=0.13.1
 regex==2023.12.25


### PR DESCRIPTION
This PR updates the NOTSOFAR-1 dataset generation recipe to additionally create single-channel Lhotse manifests. Intended use:
# Dataset generation
chime-utils dgen notsofar1 $DATA_DIR/nsf $DATA_DIR/notsofar --part="train,dev,eval"

# Lhotse manifest preparation
chime-utils lhotse-prep notsofar1 \
    -d train_sc,dev_sc,eval_sc \
    --txt-norm none -m sdm \
    $DATA_DIR/notsofar $MANIFESTS_DIR

chime-utils lhotse-prep notsofar1 \
    -d train,dev,eval \
    --txt-norm none -m mdm \
    $DATA_DIR/notsofar $MANIFESTS_DIR