### PR TITLE
Refactor requirements handling in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 from setuptools import find_packages, setup

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     requirements.append("torch")
 
+
 def read_requirements():
     requirements_file = Path(__file__).resolve().parent / "requirements.txt"
 
@@ -18,6 +19,7 @@ def read_requirements():
         for line in lines
         if line.strip() and not line.lstrip().startswith("#")
     ]
+
 
 setup(
     name="chime_utils",
@@ -32,8 +34,7 @@ setup(
     url="https://www.chimechallenge.org/",
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
-    install_requires=requirements
-    + read_requirements(),
+    install_requires=requirements + read_requirements(),
     entry_points={
         "console_scripts": [
             "chime-utils=chime_utils.bin.base:cli",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
+from pathlib import Path
 
-import pkg_resources
 from setuptools import find_packages, setup
 
 requirements = []
@@ -9,6 +9,16 @@ try:
     import torch  # noqa: F401
 except ImportError:
     requirements.append("torch")
+
+def read_requirements():
+    requirements_file = Path(__file__).resolve().parent / "requirements.txt"
+
+    lines = requirements_file.read_text(encoding="utf-8").splitlines()
+    return [
+        line.strip()
+        for line in lines
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
 
 setup(
     name="chime_utils",
@@ -24,12 +34,7 @@ setup(
     license="MIT",
     packages=find_packages(exclude=["tests*"]),
     install_requires=requirements
-    + [
-        str(r)
-        for r in pkg_resources.parse_requirements(
-            open(os.path.join(os.path.dirname(__file__), "requirements.txt"))
-        )
-    ],
+    + read_requirements(),
     entry_points={
         "console_scripts": [
             "chime-utils=chime_utils.bin.base:cli",


### PR DESCRIPTION
Refactored requirements handling by adding a read_requirements function to read from requirements.txt and removed pkg_resources dependency.

setuptools 82 removed `pkg_resources`, `importlib` is recommended to access files in the package. The install is currently failing, this fixes it.

 This caused issues in packages downstream: https://github.com/fgnt/meeteval/pull/131